### PR TITLE
Move to fixed size array for metadata

### DIFF
--- a/src/image/image.rs
+++ b/src/image/image.rs
@@ -9,9 +9,9 @@ pub struct Image<T> {
     pub width:  u32,
     pub height: u32,
     pub depth:  u32,
-    pub spacing: (f64, f64, f64),
-    pub origin:  (f64, f64, f64),
-    pub direction: (u8, u8, u8, u8, u8, u8, u8, u8, u8),
+    pub spacing: [f64; 3],
+    pub origin:  [f64; 3],
+    pub direction: [f64; 9],
 }
 
 impl<T> Image<T> {
@@ -26,9 +26,9 @@ pub trait AnyImage: Any {
     fn width(&self)  -> u32;
     fn height(&self) -> u32;
     fn depth(&self)  -> u32;
-    fn spacing(&self) -> (f64, f64, f64);
-    fn origin(&self)  -> (f64, f64, f64);
-    fn direction(&self)  -> (u8, u8, u8, u8, u8, u8, u8, u8, u8);
+    fn spacing(&self) -> [f64; 3];
+    fn origin(&self)  -> [f64; 3];
+    fn direction(&self)  -> [f64; 9];
 
     /// Iterate (lazily) through all values as f64.
     fn iter_f64(&self) -> Box<dyn Iterator<Item = f64> + '_>;
@@ -52,13 +52,13 @@ where
     fn depth(&self) -> u32 {
         self.depth
     }
-    fn spacing(&self) -> (f64, f64, f64) {
+    fn spacing(&self) -> [f64; 3] {
         self.spacing
     }
-    fn origin(&self) -> (f64, f64, f64) {
+    fn origin(&self) -> [f64; 3] {
         self.origin
     }
-    fn direction(&self) -> (u8, u8, u8, u8, u8, u8, u8, u8, u8) {
+    fn direction(&self) -> [f64; 9] {
         self.direction
     }
 

--- a/src/io/meta_image/header.rs
+++ b/src/io/meta_image/header.rs
@@ -9,12 +9,12 @@ struct RawHeader {
     binary_data: Option<bool>,
     binary_data_byte_order_msb: Option<bool>,
     compressed_data: Option<bool>,
-    transform_matrix: Option<(u8, u8, u8, u8, u8, u8, u8, u8, u8)>,
-    offset: Option<(f64, f64, f64)>,
-    center_of_rotation: Option<(f64, f64, f64)>,
+    transform_matrix: Option<[f64; 9]>,
+    offset: Option<[f64; 3]>,
+    center_of_rotation: Option<[f64; 3]>,
     anatomical_orientation: Option<String>,
-    element_spacing: Option<(f64, f64, f64)>,
-    dim_size: Option<(u32, u32, u32)>,
+    element_spacing: Option<[f64; 3]>,
+    dim_size: Option<[u32; 3]>,
     element_type: Option<String>,
     element_data_file: Option<String>,
 
@@ -26,10 +26,10 @@ struct RawHeader {
 #[derive(Debug)]
 pub(super) struct Header {
     pub compressed_data: bool,
-    pub transform_matrix: (u8, u8, u8, u8, u8, u8, u8, u8, u8),
-    pub offset: (f64, f64, f64),
-    pub element_spacing: (f64, f64, f64),
-    pub dim_size: (u32, u32, u32),
+    pub transform_matrix: [f64; 9],
+    pub offset: [f64; 3],
+    pub element_spacing: [f64; 3],
+    pub dim_size: [u32; 3],
     pub element_type: String,
     pub element_data_file: String,
     pub data_offset: u64,
@@ -108,37 +108,37 @@ pub(super) fn parse_header(filename: &str) -> Result<Header, HeaderError> {
                 "BinaryDataByteOrderMSB" => raw.binary_data_byte_order_msb = parse_bool(value),
                 "CompressedData" => raw.compressed_data = parse_bool(value),
                 "TransformMatrix" => {
-                    let mut iter = value.split_whitespace().map(|s| s.parse::<u8>().unwrap());
-                    raw.transform_matrix = Some((
+                    let mut iter = value.split_whitespace().map(|s| s.parse::<f64>().unwrap());
+                    raw.transform_matrix = Some([
                         iter.next().unwrap(), iter.next().unwrap(), iter.next().unwrap(),
                         iter.next().unwrap(), iter.next().unwrap(), iter.next().unwrap(),
                         iter.next().unwrap(), iter.next().unwrap(), iter.next().unwrap(),
-                    ));
+                    ]);
                 },
                 "Offset" => {
                     let mut iter = value.split_whitespace().map(|s| s.parse::<f64>().unwrap());
-                    raw.offset = Some((
+                    raw.offset = Some([
                         iter.next().unwrap(), iter.next().unwrap(), iter.next().unwrap(),
-                    ));
+                    ]);
                 },
                 "CenterOfRotation" => {
                     let mut iter = value.split_whitespace().map(|s| s.parse::<f64>().unwrap());
-                    raw.center_of_rotation = Some((
+                    raw.center_of_rotation = Some([
                         iter.next().unwrap(), iter.next().unwrap(), iter.next().unwrap(),
-                    ));
+                    ]);
                 },
                 "AnatomicalOrientation" => raw.anatomical_orientation = Some(value.to_string()),
                 "ElementSpacing" => {
                     let mut iter = value.split_whitespace().map(|s| s.parse::<f64>().unwrap());
-                    raw.element_spacing = Some((
+                    raw.element_spacing = Some([
                         iter.next().unwrap(), iter.next().unwrap(), iter.next().unwrap(),
-                    ));
+                    ]);
                 },
                 "DimSize" => {
                     let mut iter = value.split_whitespace().map(|s| s.parse::<u32>().unwrap());
-                    raw.dim_size = Some((
+                    raw.dim_size = Some([
                         iter.next().unwrap(), iter.next().unwrap(), iter.next().unwrap(),
-                    ));
+                    ]);
                 },
                 "ElementType" => raw.element_type = Some(value.to_string()),
                 "ElementDataFile" => {

--- a/src/io/meta_image/image.rs
+++ b/src/io/meta_image/image.rs
@@ -65,12 +65,8 @@ fn bytes_to_vec<T: Pod>(raw: Vec<u8>) -> Result<Vec<T>, &'static str> {
 pub fn load_meta_image(filename: &str) -> Box<dyn AnyImage> {
     let header = parse_header(filename).expect("Invalid Meta Image");
 
-    // First, get the voxel count in the image.
-    let (width, height, depth) = header.dim_size;
-    let voxel_count = (width as usize) * (height as usize) * (depth as usize);
-
-    // Next, init a vector with total byte size (voxels * data type)
     let etype: ElementType = header.element_type.parse().expect("Unsupported Element type!");
+    let voxel_count: usize = header.dim_size.iter().map(|&v| v as usize).product();
     let total_bytes = etype.bytes() * voxel_count;
     let mut buffer = vec![0u8; total_bytes];
 
@@ -113,9 +109,9 @@ pub fn load_meta_image(filename: &str) -> Box<dyn AnyImage> {
             let vox_vec: Vec<u8> = buffer; // already Vec<u8>
             let image = Image::<u8> {
                 voxels: vox_vec,
-                width: width as u32,
-                height: height as u32,
-                depth: depth as u32,
+                width: header.dim_size[0],
+                height: header.dim_size[1],
+                depth: header.dim_size[2],
                 spacing: header.element_spacing,
                 origin: header.offset,
                 direction: header.transform_matrix,
@@ -126,9 +122,9 @@ pub fn load_meta_image(filename: &str) -> Box<dyn AnyImage> {
             let vox_vec: Vec<i8> = buffer.iter().map(|&b| b as i8).collect();
             let image = Image::<i8> {
                 voxels: vox_vec,
-                width: width as u32,
-                height: height as u32,
-                depth: depth as u32,
+                width: header.dim_size[0],
+                height: header.dim_size[1],
+                depth: header.dim_size[2],
                 spacing: header.element_spacing,
                 origin: header.offset,
                 direction: header.transform_matrix,
@@ -139,9 +135,9 @@ pub fn load_meta_image(filename: &str) -> Box<dyn AnyImage> {
             let vox_vec: Vec<i16> = bytes_to_vec::<i16>(buffer).expect("Bad byte count");
             let image = Image::<i16> {
                 voxels: vox_vec,
-                width: width as u32,
-                height: height as u32,
-                depth: depth as u32,
+                width: header.dim_size[0],
+                height: header.dim_size[1],
+                depth: header.dim_size[2],
                 spacing: header.element_spacing,
                 origin: header.offset,
                 direction: header.transform_matrix,
@@ -152,9 +148,9 @@ pub fn load_meta_image(filename: &str) -> Box<dyn AnyImage> {
             let vox_vec: Vec<u16> = bytes_to_vec::<u16>(buffer).expect("Bad byte count");
             let image = Image::<u16> {
                 voxels: vox_vec,
-                width: width as u32,
-                height: height as u32,
-                depth: depth as u32,
+                width: header.dim_size[0],
+                height: header.dim_size[1],
+                depth: header.dim_size[2],
                 spacing: header.element_spacing,
                 origin: header.offset,
                 direction: header.transform_matrix,
@@ -165,9 +161,9 @@ pub fn load_meta_image(filename: &str) -> Box<dyn AnyImage> {
             let vox_vec: Vec<i32> = bytes_to_vec::<i32>(buffer).expect("Bad byte count");
             let image = Image::<i32> {
                 voxels: vox_vec,
-                width: width as u32,
-                height: height as u32,
-                depth: depth as u32,
+                width: header.dim_size[0],
+                height: header.dim_size[1],
+                depth: header.dim_size[2],
                 spacing: header.element_spacing,
                 origin: header.offset,
                 direction: header.transform_matrix,
@@ -178,9 +174,9 @@ pub fn load_meta_image(filename: &str) -> Box<dyn AnyImage> {
             let vox_vec: Vec<u32> = bytes_to_vec::<u32>(buffer).expect("Bad byte count");
             let image = Image::<u32> {
                 voxels: vox_vec,
-                width: width as u32,
-                height: height as u32,
-                depth: depth as u32,
+                width: header.dim_size[0],
+                height: header.dim_size[1],
+                depth: header.dim_size[2],
                 spacing: header.element_spacing,
                 origin: header.offset,
                 direction: header.transform_matrix,
@@ -191,9 +187,9 @@ pub fn load_meta_image(filename: &str) -> Box<dyn AnyImage> {
             let vox_vec: Vec<f32> = bytes_to_vec::<f32>(buffer).expect("Bad byte count");
             let image = Image::<f32> {
                 voxels: vox_vec,
-                width: width as u32,
-                height: height as u32,
-                depth: depth as u32,
+                width: header.dim_size[0],
+                height: header.dim_size[1],
+                depth: header.dim_size[2],
                 spacing: header.element_spacing,
                 origin: header.offset,
                 direction: header.transform_matrix,
@@ -204,9 +200,9 @@ pub fn load_meta_image(filename: &str) -> Box<dyn AnyImage> {
             let vox_vec: Vec<i64> = bytes_to_vec::<i64>(buffer).expect("Bad byte count");
             let image = Image::<i64> {
                 voxels: vox_vec,
-                width: width as u32,
-                height: height as u32,
-                depth: depth as u32,
+                width: header.dim_size[0],
+                height: header.dim_size[1],
+                depth: header.dim_size[2],
                 spacing: header.element_spacing,
                 origin: header.offset,
                 direction: header.transform_matrix,
@@ -217,9 +213,9 @@ pub fn load_meta_image(filename: &str) -> Box<dyn AnyImage> {
             let vox_vec: Vec<u64> = bytes_to_vec::<u64>(buffer).expect("Bad byte count");
             let image = Image::<u64> {
                 voxels: vox_vec,
-                width: width as u32,
-                height: height as u32,
-                depth: depth as u32,
+                width: header.dim_size[0],
+                height: header.dim_size[1],
+                depth: header.dim_size[2],
                 spacing: header.element_spacing,
                 origin: header.offset,
                 direction: header.transform_matrix,
@@ -230,9 +226,9 @@ pub fn load_meta_image(filename: &str) -> Box<dyn AnyImage> {
             let vox_vec: Vec<f64> = bytes_to_vec::<f64>(buffer).expect("Bad byte count");
             let image = Image::<f64> {
                 voxels: vox_vec,
-                width: width as u32,
-                height: height as u32,
-                depth: depth as u32,
+                width: header.dim_size[0],
+                height: header.dim_size[1],
+                depth: header.dim_size[2],
                 spacing: header.element_spacing,
                 origin: header.offset,
                 direction: header.transform_matrix,
@@ -302,10 +298,9 @@ where
     writeln!(header, "BinaryData = True")?;
     writeln!(header, "BinaryDataByteOrderMSB = False")?;
     writeln!(header, "CompressedData = {}", if compress { "True" } else { "False" })?;
-    let (d0, d1, d2, d3, d4, d5, d6, d7, d8) = img.direction;
-    writeln!(header, "TransformMatrix = {} {} {} {} {} {} {} {} {}", d0, d1, d2, d3, d4, d5, d6, d7, d8)?;
-    writeln!(header, "Offset = {} {} {}", img.origin.0, img.origin.1, img.origin.2)?;
-    writeln!(header, "ElementSpacing = {} {} {}", img.spacing.0, img.spacing.1, img.spacing.2)?;
+    writeln!(header, "TransformMatrix = {}", img.direction.iter().map(|v| v.to_string()).collect::<Vec<_>>().join(" "))?;
+    writeln!(header, "Offset = {}", img.origin.iter().map(|v| v.to_string()).collect::<Vec<_>>().join(" "))?;
+    writeln!(header, "ElementSpacing = {}", img.spacing.iter().map(|v| v.to_string()).collect::<Vec<_>>().join(" "))?;
     writeln!(header, "DimSize = {} {} {}", img.width, img.height, img.depth)?;
     writeln!(header, "ElementType = {}", element_type_str::<T>())?;
     writeln!(header, "ElementDataFile = {}", element_data_file)?;

--- a/tests/io_mha.rs
+++ b/tests/io_mha.rs
@@ -78,9 +78,9 @@ fn roundtrip_save_and_load_uint16() {
         width: 2,
         height: 2,
         depth: 2,
-        spacing: (1.0, 1.0, 1.0),
-        origin: (0.0, 0.0, 0.0),
-        direction: (1,0,0,0,1,0,0,0,1),
+        spacing: [1.0, 1.0, 1.0],
+        origin: [0.0, 0.0, 0.0],
+        direction: [1.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,1.0],
     };
     let path = "test_uint16.mha";
     save_meta_image(&img, path, false).unwrap();
@@ -92,9 +92,9 @@ fn roundtrip_save_and_load_uint16() {
     assert_eq!(loaded.width(), 2);
     assert_eq!(loaded.height(), 2);
     assert_eq!(loaded.depth(), 2);
-    assert_eq!(loaded.spacing(), (1.0, 1.0, 1.0));
-    assert_eq!(loaded.origin(), (0.0, 0.0, 0.0));
-    assert_eq!(loaded.direction(), (1,0,0,0,1,0,0,0,1));
+    assert_eq!(loaded.spacing(), [1.0, 1.0, 1.0]);
+    assert_eq!(loaded.origin(), [0.0, 0.0, 0.0]);
+    assert_eq!(loaded.direction(), [1.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,1.0]);
 
     // Check voxel values
     let loaded_voxels: Vec<u16> = loaded.iter_f64().map(|v| v as u16).collect();
@@ -113,9 +113,9 @@ fn roundtrip_save_and_load_uint16_compressed() {
         width: 2,
         height: 2,
         depth: 2,
-        spacing: (1.0, 1.0, 1.0),
-        origin: (0.0, 0.0, 0.0),
-        direction: (1,0,0,0,1,0,0,0,1),
+        spacing: [1.0, 1.0, 1.0],
+        origin: [0.0, 0.0, 0.0],
+        direction: [1.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,1.0],
     };
     let path = "test_uint16_compressed.mha";
     save_meta_image(&img, path, true).unwrap();
@@ -127,9 +127,9 @@ fn roundtrip_save_and_load_uint16_compressed() {
     assert_eq!(loaded.width(), 2);
     assert_eq!(loaded.height(), 2);
     assert_eq!(loaded.depth(), 2);
-    assert_eq!(loaded.spacing(), (1.0, 1.0, 1.0));
-    assert_eq!(loaded.origin(), (0.0, 0.0, 0.0));
-    assert_eq!(loaded.direction(), (1,0,0,0,1,0,0,0,1));
+    assert_eq!(loaded.spacing(), [1.0, 1.0, 1.0]);
+    assert_eq!(loaded.origin(), [0.0, 0.0, 0.0]);
+    assert_eq!(loaded.direction(), [1.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,1.0]);
 
     // Check voxel values
     let loaded_voxels: Vec<u16> = loaded.iter_f64().map(|v| v as u16).collect();

--- a/tests/io_mhd.rs
+++ b/tests/io_mhd.rs
@@ -78,9 +78,9 @@ fn roundtrip_save_and_load_uint16() {
         width: 2,
         height: 2,
         depth: 2,
-        spacing: (1.0, 1.0, 1.0),
-        origin: (0.0, 0.0, 0.0),
-        direction: (1,0,0,0,1,0,0,0,1),
+        spacing: [1.0, 1.0, 1.0],
+        origin: [0.0, 0.0, 0.0],
+        direction: [1.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,1.0],
     };
     let path = "test_uint16.mhd";
     save_meta_image(&img, path, false).unwrap();
@@ -92,9 +92,9 @@ fn roundtrip_save_and_load_uint16() {
     assert_eq!(loaded.width(), 2);
     assert_eq!(loaded.height(), 2);
     assert_eq!(loaded.depth(), 2);
-    assert_eq!(loaded.spacing(), (1.0, 1.0, 1.0));
-    assert_eq!(loaded.origin(), (0.0, 0.0, 0.0));
-    assert_eq!(loaded.direction(), (1,0,0,0,1,0,0,0,1));
+    assert_eq!(loaded.spacing(), [1.0, 1.0, 1.0]);
+    assert_eq!(loaded.origin(), [0.0, 0.0, 0.0]);
+    assert_eq!(loaded.direction(), [1.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,1.0]);
 
     // Check voxel values
     let loaded_voxels: Vec<u16> = loaded.iter_f64().map(|v| v as u16).collect();
@@ -114,9 +114,9 @@ fn roundtrip_save_and_load_uint16_compressed() {
         width: 2,
         height: 2,
         depth: 2,
-        spacing: (1.0, 1.0, 1.0),
-        origin: (0.0, 0.0, 0.0),
-        direction: (1,0,0,0,1,0,0,0,1),
+        spacing: [1.0, 1.0, 1.0],
+        origin: [0.0, 0.0, 0.0],
+        direction: [1.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,1.0],
     };
     let path = "test_uint16_compressed.mhd";
     save_meta_image(&img, path, true).unwrap();
@@ -128,9 +128,9 @@ fn roundtrip_save_and_load_uint16_compressed() {
     assert_eq!(loaded.width(), 2);
     assert_eq!(loaded.height(), 2);
     assert_eq!(loaded.depth(), 2);
-    assert_eq!(loaded.spacing(), (1.0, 1.0, 1.0));
-    assert_eq!(loaded.origin(), (0.0, 0.0, 0.0));
-    assert_eq!(loaded.direction(), (1,0,0,0,1,0,0,0,1));
+    assert_eq!(loaded.spacing(), [1.0, 1.0, 1.0]);
+    assert_eq!(loaded.origin(), [0.0, 0.0, 0.0]);
+    assert_eq!(loaded.direction(), [1.0,0.0,0.0,0.0,1.0,0.0,0.0,0.0,1.0]);
 
     // Check voxel values
     let loaded_voxels: Vec<u16> = loaded.iter_f64().map(|v| v as u16).collect();


### PR DESCRIPTION
NB: this also changes the direction dtype from unsigned integers to fp64 (more fitting).